### PR TITLE
docs: fix README typos and add usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,46 @@
 # node-canvas-lms
 
 
-A very simple node.js wrapper for the Canvas LMS API
+A very simple Node.js wrapper for the Canvas LMS API
 
 ## Usage
 ```js
 var Canvas = require('node-canvas-lms');
 
-var class = new Canvas('YOUR-HOST',
-    { token: 'YOUR-TOKEN',
-      version: 'optional defaults to v1'
-    });
+var canvas = new Canvas('YOUR-HOST', {
+  token: 'YOUR-TOKEN',
+  version: 'v1',
+});
+
+canvas.get('courses', function (err, response, body) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  console.log(body);
+});
+```
+
+## API usage examples
+
+```js
+// Post with form data
+canvas.post(
+  'courses',
+  { per_page: 100 },
+  {
+    name: 'Canvas API Example Course',
+  },
+  function (err, response, body) {
+    if (err) {
+      console.error(err);
+      return;
+    }
+
+    console.log(response.statusCode, body.id);
+  }
+);
 ```
 
 ## Development
@@ -18,4 +48,3 @@ var class = new Canvas('YOUR-HOST',
 The master branch tracks the stable version, which is published to npm. Development occurs on the [dev branch][dev]. Currently This is going through a pretty big update, so be sure to check that out.
 
 [dev]: https://github.com/cs10/node-canvas-lms/tree/dev
-


### PR DESCRIPTION
## Summary
- Fix `README.md` typos and improve phrasing in API usage docs.
- Add a concrete usage example for the `get` API call and basic parameters.
- Keep changes limited to documentation in `README.md`.

## Validation
- Ran `npm run check` in this repo; it fails because the project has no `check` script (`Missing script: "check").
